### PR TITLE
warn on reflection in tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "http://github.com/vitalreactor/fressian-clojure"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.fressian/fressian "0.6.2"]])
 


### PR DESCRIPTION
Just means we can see any reflection warnings that come up -
serialization is often a bottleneck for many applications, so we
shouldn't have reflection warnings.
